### PR TITLE
Changing version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ except(IOError, ImportError):
 
 setup(
     name='redbiom',
-    version='0.1.0',
+    version='0.1.0-dev',
     license='BSD-3-Clause',
     author='Daniel McDonald',
     author_email='wasade@gmail.com',


### PR DESCRIPTION
Other tools using the current master version may fail to start with an error from dist-packages, because the version number doesn't match the one in setup.py. If trying to install it naming it 0.1.0 it will download the tagged branch, rather than the current master version.