### PR TITLE
PERF: sortedset to list for feature and sample data

### DIFF
--- a/redbiom/admin.py
+++ b/redbiom/admin.py
@@ -15,10 +15,9 @@ class ScriptManager:
                     local result = {}
                     local formedkey = context .. ':' .. 'feature' .. ':' .. key
 
-                    local items = redis.call('ZRANGEBYSCORE',
+                    local items = redis.call('LRANGE',
                                              formedkey,
-                                             '-inf', 'inf',
-                                             'withscores')
+                                             '0', '-1')
 
                     -- adapted from https://gist.github.com/klovadis/5170446
                     local resultkey
@@ -39,10 +38,9 @@ class ScriptManager:
                     local result = {}
                     local formedkey = context .. ':' .. 'sample' .. ':' .. key
 
-                    local items = redis.call('ZRANGEBYSCORE',
+                    local items = redis.call('LRANGE',
                                              formedkey,
-                                             '-inf', 'inf',
-                                             'withscores')
+                                             '0', '-1')
 
                     -- adapted from https://gist.github.com/klovadis/5170446
                     local resultkey
@@ -203,8 +201,8 @@ def load_sample_data(table, context, tag=None, redis_protocol=False):
     ---------------------
     EVALSHA <get-index-sha1> 1 <context>:feature-index <feature_id>
     EVALSHA <get-index-sha1> 1 <context>:sample-index <redbiom_id>
-    ZADD <context>:samples:<redbiom_id> <count> <feature_id> ...
-    ZADD <context>:features:<redbiom_id> <count> <redbiom_id> ...
+    LPUSH <context>:samples:<redbiom_id> <count> <feature_id> ...
+    LPUSH <context>:features:<redbiom_id> <count> <redbiom_id> ...
     SADD <context>:samples-represented <redbiom_id> ... <redbiom_id>
     SADD <context>:features-represented <feature_id> ... <feature_id>
 
@@ -243,7 +241,7 @@ def load_sample_data(table, context, tag=None, redis_protocol=False):
         packed = '/'.join(["%d/%s" % (v, i)
                            for i, v in zip(remapped,
                                            int_values.data)])
-        post(context, 'ZADD', 'sample:%s/%s' % (id_, packed))
+        post(context, 'LPUSH', 'sample:%s/%s' % (id_, packed))
 
     payload = "samples-represented/%s" % '/'.join(samples)
     post(context, 'SADD', payload)
@@ -256,7 +254,7 @@ def load_sample_data(table, context, tag=None, redis_protocol=False):
         packed = '/'.join(["%d/%s" % (v, i)
                            for i, v in zip(remapped,
                                            int_values.data)])
-        post(context, 'ZADD', 'feature:%s/%s' % (id_, packed))
+        post(context, 'LPUSH', 'feature:%s/%s' % (id_, packed))
 
     payload = "features-represented/%s" % '/'.join(obs)
     post(context, 'SADD', payload)

--- a/redbiom/tests/test_rest.py
+++ b/redbiom/tests/test_rest.py
@@ -42,9 +42,9 @@ class RESTTests(unittest.TestCase):
         inv_index = get('HGETALL', 'test:sample-index-inverted')
         for values, id_, _ in table.iter(axis='observation'):
             exp = set(sample_ids[values > 0])
-            obs = get('ZRANGEBYSCORE', 'test:feature:%s/%s/%s' %
-                      (id_, '-inf', 'inf'))
-            obs = {inv_index[i] for i in obs}
+            obs = get('LRANGE', 'test:feature:%s/%s/%s' %
+                      (id_, '0', '-1'))
+            obs = {inv_index[i] for i in obs[::2]}
             self.assertEqual(obs, exp)
 
     def test_sample_data(self):
@@ -64,9 +64,9 @@ class RESTTests(unittest.TestCase):
             exp_ids = feature_ids[values > 0]
             exp_dict = {i: v for i, v in zip(exp_ids, exp_data)}
 
-            obs = get('ZRANGEBYSCORE',
-                      'test:sample:UNTAGGED_%s/%s/%s/%s' %
-                      (id_, "-inf", "inf", "withscores"))
+            obs = get('LRANGE',
+                      'test:sample:UNTAGGED_%s/%s/%s' %
+                      (id_, "0", "-1"))
             obs_dict = {inv_index[i]: float(v) for i, v in zip(obs[::2],
                                                                obs[1::2])}
 

--- a/redbiom/util.py
+++ b/redbiom/util.py
@@ -126,7 +126,7 @@ def float_or_nan(t):
     import numpy as np
     try:
         return float(t)
-    except:  # noqa
+    except Exception as e:
         return np.nan
 
 
@@ -352,5 +352,5 @@ def stems(stops, stemmer, string):
 
         try:
             yield stemmer.stem(word).lower()
-        except:  # noqa
+        except Exception as e:
             continue

--- a/redbiom/util.py
+++ b/redbiom/util.py
@@ -126,7 +126,7 @@ def float_or_nan(t):
     import numpy as np
     try:
         return float(t)
-    except:
+    except:  # noqa
         return np.nan
 
 
@@ -352,5 +352,5 @@ def stems(stops, stemmer, string):
 
         try:
             yield stemmer.stem(word).lower()
-        except:
+        except:  # noqa
             continue

--- a/redbiom/util.py
+++ b/redbiom/util.py
@@ -126,7 +126,7 @@ def float_or_nan(t):
     import numpy as np
     try:
         return float(t)
-    except Exception as e:
+    except Exception:
         return np.nan
 
 
@@ -352,5 +352,5 @@ def stems(stops, stemmer, string):
 
         try:
             yield stemmer.stem(word).lower()
-        except Exception as e:
+        except Exception:
             continue

--- a/test.sh
+++ b/test.sh
@@ -147,7 +147,7 @@ md5test obs_anewid.txt exp_anewid.txt
 redbiom search metadata "where AGE_YEARS > 40" | redbiom fetch samples --context test --output metadata_search_test.biom
 echo "Num samples: 2" > exp_metadata_search.txt
 echo "Num observations: 425" >> exp_metadata_search.txt
-echo "Total count: 21462" >> exp_metadata_search.txt
+echo "Total count: 21,462" >> exp_metadata_search.txt
 biom summarize-table -i metadata_search_test.biom | head -n 3 > obs_metadata_search.txt
 md5test obs_metadata_search.txt exp_metadata_search.txt
 


### PR DESCRIPTION
Represent sample and feature data as a list structure instead of a sorted set. This is should yield a reasonable reduction in memory consumption, and potentially some minor performance gains. 

It's tempting to store index and data in two separate lists within redis, however this would yield 2x the number of keys which could easily result in an large increase in memory consumption as for Qiita this would mean > 10M additional keys. On the other hand, this approach could yield performance gains by reducing the number of calls to `redis.call` substantially. One reason this strategy was not explored immediately was it was unclear how to expand a Lua table into varargs, and at the time of exploring how to make these changes, I didn't have internet availalbe. `unpack` seems like a plausible candidate but was unsuccessful in practice; on googling there are likely some solutions to explore [here](http://lua-users.org/wiki/VarargTheSecondClassCitizen). 