### PR TITLE
Remap IDs to simplify storage for taxonomy, and simplify structures used for taxonomy

### DIFF
--- a/redbiom/admin.py
+++ b/redbiom/admin.py
@@ -267,7 +267,7 @@ def load_sample_data(table, context, tag=None, redis_protocol=False):
         hmgetter = redbiom._requests.buffered
 
         tip_names = {n.name: n for n in taxonomy.tips()}
-        ids_ = hmgetter(tip_names.keys(), None, 'HMGET', context,
+        ids_ = hmgetter(tip_names, None, 'HMGET', context,
                         get=get, buffer_size=100,
                         multikey='feature-index')
         ids = []

--- a/redbiom/admin.py
+++ b/redbiom/admin.py
@@ -270,7 +270,7 @@ def load_sample_data(table, context, tag=None, redis_protocol=False):
         ids_ = hmgetter(tip_names, None, 'HMGET', context,
                         get=get, buffer_size=100,
                         multikey='feature-index')
-        ids = []
+
         for blk in ids_:
             for entity, idx in zip(*blk):
                 tip_names[entity].name = idx

--- a/redbiom/commands/summarize.py
+++ b/redbiom/commands/summarize.py
@@ -204,7 +204,6 @@ def taxonomy(from_, context, normalize_ranks, features):
     import redbiom.fetch
     lineages = redbiom.fetch.taxon_ancestors(context, ids,
                                              normalize=normalize_ranks)
-    print(lineages)
 
     import skbio
     tree = skbio.TreeNode.from_taxonomy([(i, l)

--- a/redbiom/commands/summarize.py
+++ b/redbiom/commands/summarize.py
@@ -204,6 +204,7 @@ def taxonomy(from_, context, normalize_ranks, features):
     import redbiom.fetch
     lineages = redbiom.fetch.taxon_ancestors(context, ids,
                                              normalize=normalize_ranks)
+    print(lineages)
 
     import skbio
     tree = skbio.TreeNode.from_taxonomy([(i, l)

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -472,7 +472,8 @@ def taxon_descendents(context, taxon, get=None):
                 tips = get(context, 'SMEMBERS', 'terminal-of:%s' % parent)
                 to_keep.update(set(tips))
             else:
-                gotten = get(context, 'SMEMBERS', 'taxonomy-children:%s' % taxon)
+                gotten = get(context, 'SMEMBERS',
+                             'taxonomy-children:%s' % taxon)
                 new_to_get.extend([(taxon, child) for child in gotten])
         to_get = new_to_get
 

--- a/redbiom/tests/test_admin.py
+++ b/redbiom/tests/test_admin.py
@@ -187,7 +187,8 @@ class AdminTests(unittest.TestCase):
         # has an unclassified genus, so it should have tips directly descending
         f__Actinomycetaceae = {'g__Varibaculum',
                                'g__Actinomyces',
-                               'terminal:TACGTAGGGCGCGAGCGTTGTCCGGAATTATTGGGCGTAAAGGGCTCGTAGGCGGCTTGTCGCGTCTGCTGTGAAAATGCGGGGCTTAACTCCGTACGTG'}  # noqa
+                               'has-terminal'}
+        f__Actinomycetaceae_terminal = 'TACGTAGGGCGCGAGCGTTGTCCGGAATTATTGGGCGTAAAGGGCTCGTAGGCGGCTTGTCGCGTCTGCTGTGAAAATGCGGGGCTTAACTCCGTACGTG'  # noqa
 
         obs_bacteria = self.get(context, 'SMEMBERS',
                                 ':'.join(['taxonomy-children',
@@ -198,12 +199,24 @@ class AdminTests(unittest.TestCase):
                                                   'f__Actinomycetaceae']))
         self.assertEqual(set(obs_Actinomycetaceae), f__Actinomycetaceae)
 
+        key = 'terminal-of:f__Actinomycetaceae'
+        obs_Actinomycetaceae_terminal = self.get(context, 'SMEMBERS', key)
+        print(obs_Actinomycetaceae_terminal)
+        self.assertEqual(len(obs_Actinomycetaceae_terminal), 1)
+        id_ = obs_Actinomycetaceae_terminal[0]
+        key = 'feature-index-inverted/%d' % int(id_)
+        obs_Actinomycetaceae_terminal = self.get(context, 'HGET', key)
+        self.assertEqual(obs_Actinomycetaceae_terminal,
+                         f__Actinomycetaceae_terminal)
+
         exp_parents = [('p__Firmicutes', 'k__Bacteria'),
                        ('p__Fusobacteria', 'k__Bacteria'),
                        ('g__Actinomyces', 'f__Actinomycetaceae'),
-                       ('TACGTAGGGCGCGAGCGTTGTCCGGAATTATTGGGCGTAAAGGGCTCGTAGGCGGCTTGTCGCGTCTGCTGTGAAAATGCGGGGCTTAACTCCGTACGTG', 'f__Actinomycetaceae')]  # noqa
+                       (id_, 'f__Actinomycetaceae')]
         for name, exp in exp_parents:
             obs = self.get(context, 'HGET', 'taxonomy-parents/%s' % name)
+            print(name, exp)
+            print(obs)
             self.assertEqual(obs, exp)
 
     def test_load_sample_metadata(self):

--- a/redbiom/tests/test_admin.py
+++ b/redbiom/tests/test_admin.py
@@ -201,7 +201,6 @@ class AdminTests(unittest.TestCase):
 
         key = 'terminal-of:f__Actinomycetaceae'
         obs_Actinomycetaceae_terminal = self.get(context, 'SMEMBERS', key)
-        print(obs_Actinomycetaceae_terminal)
         self.assertEqual(len(obs_Actinomycetaceae_terminal), 1)
         id_ = obs_Actinomycetaceae_terminal[0]
         key = 'feature-index-inverted/%d' % int(id_)
@@ -215,8 +214,6 @@ class AdminTests(unittest.TestCase):
                        (id_, 'f__Actinomycetaceae')]
         for name, exp in exp_parents:
             obs = self.get(context, 'HGET', 'taxonomy-parents/%s' % name)
-            print(name, exp)
-            print(obs)
             self.assertEqual(obs, exp)
 
     def test_load_sample_metadata(self):

--- a/redbiom/util.py
+++ b/redbiom/util.py
@@ -326,11 +326,11 @@ def stems(stops, stemmer, string):
     to_skip.update(NULL_VALUES)
 
     # match numbers (doesn't catch sci notation...)
-    numeric_regex = re.compile('(^-?\d+\.\d+$)|(^-?\d+$)')
+    numeric_regex = re.compile(r'(^-?\d+\.\d+$)|(^-?\d+$)')
 
     # time like. we don't actually care if this doesn't match time
     # as things like 1234:23123 are probably not useful for *general* search
-    time_regex = re.compile("^\d+:\d+(am|AM|pm|PM)?$")
+    time_regex = re.compile(r"^\d+:\d+(am|AM|pm|PM)?$")
 
     if string in to_skip:
         raise StopIteration

--- a/test.sh
+++ b/test.sh
@@ -150,7 +150,7 @@ md5test obs_metadata_counts.txt exp_metadata_counts.txt
 # load table with some duplicate sample IDs
 head -n 1 test.txt > test.with_dups.txt
 tail -n 2 test.txt >> test.with_dups.txt
-tail -n 1 test.txt | sed -s 's/^10317\.[0-9]*/anewID/' >> test.with_dups.txt
+tail -n 1 test.txt | sed 's/^10317\.[0-9]*/anewID/' >> test.with_dups.txt
 echo "Loaded 1 samples" > exp_load_count.txt
 redbiom admin load-sample-metadata --metadata test.with_dups.txt > obs_load_count.txt
 md5test obs_load_count.txt exp_load_count.txt


### PR DESCRIPTION
A partial rewrite of the taxonomy structure is included in this PR. The motivation is to greatly reduce the memory overhead for storing sOTUs. The reduction in memory overhead has *not* been benchmarked. However, I don't believe that is necessary as the savings are straight forward in concept:

- identifiers are remapped to their internal integer variants that are already available which reduces the amount of storage needed for an ID by 10-20x (8 bytes vs. 150 bytes for a 150nt sOTU).
- allow for using Redis's internal optimization when storing only integers as opposed to mixed datatypes within structures. This strategy uses "...up to 10 times less memory (with 5 time less memory used being the average saving)" ([src](https://redis.io/topics/memory-optimization)) 

The first point did not require a reorganization of the taxonomy data structure. The second required splitting `taxonomy-children` such that it either stores taxon names (strings) or the sentinel `has-terminal`. Tips are then stored as a set of integers under the `terminal-of` key which contains a reference to the parent taxon. This split does add keys, but the number of keys added is equal to the number of taxa which have a terminal descending which is << than the number of total tips spanned by the taxonomy. 

It is the case that the code surrounding taxonomy is complex, and warrants a refactor. I believe a refactor is out of scope for this PR as the intent here is to enable storage of taxonomy data for Deblur tables. 