### PR TITLE
Obtain the tags associated with samples in a context

### DIFF
--- a/redbiom/commands/fetch.py
+++ b/redbiom/commands/fetch.py
@@ -9,6 +9,16 @@ def fetch():
     pass
 
 
+@fetch.command(name='tags-contained')
+@click.option('--context', required=True, type=str, default=None,
+              help="The context to fetch from.")
+def fetch_tags_contained(context):
+    """Get the observed tags within a context"""
+    import redbiom.fetch
+    for id_ in redbiom.fetch.tags_in_context(context):
+        click.echo(id_)
+
+
 @fetch.command(name='samples-contained')
 @click.option('--context', required=False, type=str, default=None,
               help="The context to fetch from.")

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -1,3 +1,42 @@
+def tags_in_context(context, get=None):
+    """Fetch the unique tags within a context
+
+    Parameters
+    ----------
+    context : str
+        The context to obtain tags from.
+
+    Returns
+    -------
+    set
+        The set of sample identifers within a context.
+
+    Raises
+    ------
+    ValueError
+        If the requested context is not known.
+
+    Redis Command Summary
+    ---------------------
+    SMEMBERS <context>:samples-represented
+    """
+    import redbiom
+    import redbiom._requests
+    import redbiom.util
+
+    if get is None:
+        config = redbiom.get_config()
+        get = redbiom._requests.make_get(config)
+
+    redbiom._requests.valid(context, get)
+
+    obs = get(context, 'SMEMBERS', 'samples-represented')
+
+    _, _, tags, _ = redbiom.util.partition_samples_by_tags(obs)
+
+    return set(tags)
+
+
 def samples_in_context(context, unambiguous, get=None):
     """Fetch samples in a context
 

--- a/redbiom/tests/test_fetch.py
+++ b/redbiom/tests/test_fetch.py
@@ -54,6 +54,22 @@ class FetchTests(unittest.TestCase):
         exp = {'tagged_%s' % i for i in table3.ids()}
         self.assertEqual(obs, exp)
 
+    def test_tags_in_context(self):
+        redbiom.admin.create_context('test', 'a nice test')
+        redbiom.admin.load_sample_metadata(metadata)
+        redbiom.admin.load_sample_data(table, 'test', tag=None)
+
+        exp = {'UNTAGGED', }
+        obs = redbiom.fetch.tags_in_context('test')
+        self.assertEqual(obs, exp)
+
+        redbiom.admin.load_sample_data(table, 'test', tag='foo')
+        redbiom.admin.load_sample_data(table, 'test', tag='bar')
+
+        exp = {'foo', 'bar', 'UNTAGGED'}
+        obs = redbiom.fetch.tags_in_context('test')
+        self.assertEqual(obs, exp)
+
     def test_features_in_context(self):
         redbiom.admin.create_context('test', 'a nice test')
         redbiom.admin.load_sample_metadata(metadata)


### PR DESCRIPTION
This pull request allows a user to obtain the tags associated with the cached data. This is helpful for performing regular cache updates as, in the case of Qiita, table data do not need to be reloaded of the tag (artifact ID) exists.