### PR TITLE
Encode variable values for use over URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: true
 language: python
 env:
-  - PYTHON_VERSION=3.7
   - PYTHON_VERSION=3.6
   - PYTHON_VERSION=3.5
 services:
@@ -16,6 +15,7 @@ before_install:
 install:
   - conda create --yes -n test-env -c bioconda python=$PYTHON_VERSION biom-format requests pandas click==6.7 nose sqlite joblib nltk msgpack-python cython
   - source activate test-env
+  - conda install -c conda-forge --yes scikit-bio
   - pip install flake8 msgpack
   - git clone https://github.com/nicolasff/webdis
   - pushd webdis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: true
 language: python
 env:
+  - PYTHON_VERSION=3.7
   - PYTHON_VERSION=3.6
   - PYTHON_VERSION=3.5
-  - PYTHON_VERSION=2.7
 services:
   - redis-server
 before_install:
@@ -16,9 +16,6 @@ before_install:
 install:
   - conda create --yes -n test-env -c bioconda python=$PYTHON_VERSION biom-format requests pandas click==6.7 nose sqlite joblib nltk msgpack-python cython
   - source activate test-env
-  - if [ ${PYTHON_VERSION} = "2.7" ]; then conda install -c biocore --yes scikit-bio==0.4.2; fi
-  - if [ ${PYTHON_VERSION} = "3.5" ]; then conda install -c conda-forge --yes scikit-bio; fi
-  - if [ ${PYTHON_VERSION} = "3.6" ]; then conda install -c conda-forge --yes scikit-bio; fi
   - pip install flake8 msgpack
   - git clone https://github.com/nicolasff/webdis
   - pushd webdis

--- a/redbiom/admin.py
+++ b/redbiom/admin.py
@@ -465,16 +465,11 @@ def load_sample_metadata(md, tag=None):
         put('metadata', 'SET', key, json.dumps(columns))
 
     for col in indexed_columns:
-        try:
-            bulk_set = ["%s/%s" % (idx, quote_plus(str(v)))
-                        for idx, v in zip(md.index, md[col])
-                        if _indexable(v, null_values)]
-            payload = "category:%s/%s" % (col, '/'.join(bulk_set))
-            post('metadata', 'HMSET', payload)
-
-        except:
-            print(col)
-            print(md[col])
+        bulk_set = ["%s/%s" % (idx, quote_plus(str(v)))
+                    for idx, v in zip(md.index, md[col])
+                    if _indexable(v, null_values)]
+        payload = "category:%s/%s" % (col, '/'.join(bulk_set))
+        post('metadata', 'HMSET', payload)
 
     payload = "samples-represented/%s" % '/'.join(md.index)
     post('metadata', 'SADD', payload)
@@ -554,10 +549,7 @@ def load_sample_metadata_full_search(md, tag=None):
 
 def _indexable(value, nullables):
     """Returns true if the value appears to be something that storable"""
-    if value in nullables:
-        return False
-    else:
-        return True
+    return value not in nullables
 
 
 class AlreadyLoaded(ValueError):

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -703,6 +703,8 @@ def get_sample_values(samples, category, get=None):
         The samples to obtain
     category : str
         The category to obtain values for.
+    get : function, optional
+        A get method
 
     Returns
     -------
@@ -712,6 +714,7 @@ def get_sample_values(samples, category, get=None):
     Redis command summary
     ---------------------
     HMGET metadata:category:<column> <sample_id> ... <sample_id>
+    HMKEYS metadata:category:<column>
     """
     import redbiom
 

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -222,16 +222,9 @@ def sample_metadata(samples, common=True, context=None, restrict_to=None,
             metadata[sample_ambiguity]['#SampleID'] = sample_ambiguity
 
     for category in columns_to_get:
-        key = 'category:%s' % category
-        getter = redbiom._requests.buffered(iter(all_samples), None, 'HMGET',
-                                            'metadata', get=get,
-                                            buffer_size=100,
-                                            multikey=key)
-
-        for samples, category_values in getter:
-            for sample, value in zip(samples, category_values):
-                for sample_ambiguity in ambig_assoc[sample]:
-                    metadata[sample_ambiguity][category] = value
+        for sample, value in get_sample_values(all_samples, category):
+            for sample_ambiguity in ambig_assoc[sample]:
+                metadata[sample_ambiguity][category] = value
 
     md = pd.DataFrame(metadata).T
 
@@ -564,20 +557,12 @@ def category_sample_values(category, samples=None):
 
     get = redbiom._requests.make_get(redbiom.get_config())
 
-    key = 'category:%s' % category
-    if samples is None:
-        keys_vals = list(get('metadata', 'HGETALL', key).items())
-    else:
+    if samples is not None:
         untagged, _, _, tagged_clean = \
             redbiom.util.partition_samples_by_tags(samples)
         samples = untagged + tagged_clean
-        getter = redbiom._requests.buffered(iter(samples), None, 'HMGET',
-                                            'metadata', get=get,
-                                            buffer_size=100, multikey=key)
 
-        # there is probably some niftier method than this.
-        keys_vals = [(sample, obs_val) for idx, vals in getter
-                     for sample, obs_val in zip(idx, vals)]
+    keys_vals = get_sample_values(samples, category, get=get)
 
     index = (v[0] for v in keys_vals)
     data = (v[1] for v in keys_vals)
@@ -697,16 +682,8 @@ def metadata(where=None, tag=None, restrict_to=None):
         metadata[sample]['#SampleID'] = sample
 
     for category in categories:
-        key = 'category:%s' % category
-        getter = redbiom._requests.buffered(iter(samples_to_get), None,
-                                            'HMGET',
-                                            'metadata', get=get,
-                                            buffer_size=100,
-                                            multikey=key)
-
-        for chunk in getter:
-            for sample, value in zip(*chunk):
-                metadata[sample][category] = value
+        for sample, value in get_sample_values(samples_to_get, category, get):
+            metadata[sample][category] = value
 
     md = pd.DataFrame(metadata).T
 
@@ -715,3 +692,41 @@ def metadata(where=None, tag=None, restrict_to=None):
     else:
         md = redbiom.metadata.Metadata(md.set_index('#SampleID'))
         return md.ids(where=where)
+
+
+def get_sample_values(samples, category, get=None):
+    """Obtain the metadata values associated with the requested samples
+
+    Parameters
+    ----------
+    samples : Iterable of str or None
+        The samples to obtain
+    category : str
+        The category to obtain values for.
+
+    Returns
+    -------
+    [(str, str), ...]
+        A list of (sample, value) tuples
+
+    Redis command summary
+    ---------------------
+    HMGET metadata:category:<column> <sample_id> ... <sample_id>
+    """
+    import redbiom
+
+    if get is None:
+        config = redbiom.get_config()
+        get = redbiom._requests.make_get(config)
+
+    key = 'category:%s' % category
+    if samples is None:
+        samples = get('metadata', 'HKEYS', key)
+
+    getter = redbiom._requests.buffered(iter(samples), None,
+                                        'HMGET',
+                                        'metadata', get=get,
+                                        buffer_size=100,
+                                        multikey=key)
+
+    return [item for chunk in getter for item in zip(*chunk)]

--- a/redbiom/tests/test_admin.py
+++ b/redbiom/tests/test_admin.py
@@ -274,8 +274,11 @@ class AdminTests(unittest.TestCase):
                                         'thing', 'stuff', 'asd#asd',
                                         'a', 'b', 'c']
         redbiom.admin.load_sample_metadata(md)
-        exp = ['foo', 'bar', 'foo%2Fbar', 'baz%2412',
-               'thing', 'stuff', 'asd%23asd', 'a', 'b', 'c']
+
+        # NOTE: webdis decodes the encoded strings so they are stored in redis
+        # in their native representation
+        exp = ['foo', 'bar', 'foo/bar', 'baz$12',
+               'thing', 'stuff', 'asd#asd', 'a', 'b', 'c']
         obs = self.get('metadata:category', 'HGETALL',
                        'http_quoted_characters')
         self.assertEqual(sorted([v for k, v in obs.items()]),

--- a/redbiom/tests/test_admin.py
+++ b/redbiom/tests/test_admin.py
@@ -268,6 +268,19 @@ class AdminTests(unittest.TestCase):
         obs = set(self.get('metadata', 'SMEMBERS', 'samples-represented'))
         self.assertEqual(obs, exp)
 
+    def test_load_sample_metadata_encoded(self):
+        md = metadata.copy()
+        md['http_quoted_characters'] = ['foo', 'bar', 'foo/bar', 'baz$12',
+                                        'thing', 'stuff', 'asd#asd',
+                                        'a', 'b', 'c']
+        redbiom.admin.load_sample_metadata(md)
+        exp = ['foo', 'bar', 'foo%2Fbar', 'baz%2412',
+               'thing', 'stuff', 'asd%23asd', 'a', 'b', 'c']
+        obs = self.get('metadata:category', 'HGETALL',
+                       'http_quoted_characters')
+        self.assertEqual(sorted([v for k, v in obs.items()]),
+                         sorted(exp))
+
     def test_load_sample_metadata_full_search(self):
         redbiom.admin.load_sample_metadata(metadata)
         redbiom.admin.load_sample_metadata_full_search(metadata)

--- a/redbiom/tests/test_fetch.py
+++ b/redbiom/tests/test_fetch.py
@@ -238,7 +238,9 @@ class FetchTests(unittest.TestCase):
                 '10317.000012975'], 'encoded'] = ['foo/bar',
                                                   'baz$',
                                                   '#bing']
-        redbiom.admin.load_sample_metadata(metadata)
+        df.loc[df['encoded'].isnull(), 'encoded'] = None
+
+        redbiom.admin.load_sample_metadata(df)
         exp = {'10317.000047188': 'foo/bar',
                '10317.000051129': 'baz$',
                '10317.000012975': '#bing'}

--- a/redbiom/tests/test_rest.py
+++ b/redbiom/tests/test_rest.py
@@ -85,7 +85,7 @@ class RESTTests(unittest.TestCase):
 
         for idx, row in md.iterrows():
             exp = [c for c, v in zip(md.columns, row.values)
-                   if v not in null_values and '/' not in str(v)]
+                   if v not in null_values]
             obs = json.loads(get('GET', 'metadata:categories:%s' % idx))
 
             self.assertEqual(obs, exp)


### PR DESCRIPTION
This PR allows variable values such as "foo/bar" to be stored. Previously these had been omitted due to overload of the "/" character for use with URLs. These values are now formally encoded using `urllib`. 