### PR TITLE
Escape periods

### DIFF
--- a/redbiom/admin.py
+++ b/redbiom/admin.py
@@ -1,4 +1,8 @@
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus as _quote_plus
+
+
+def quote_plus(s):
+    return _quote_plus(s).replace('.', '%2E')
 
 
 class ScriptManager:

--- a/redbiom/tests/test_admin.py
+++ b/redbiom/tests/test_admin.py
@@ -284,6 +284,31 @@ class AdminTests(unittest.TestCase):
         self.assertEqual(sorted([v for k, v in obs.items()]),
                          sorted(exp))
 
+    def test_load_sample_metadata_content_type_bug(self):
+        # webdis interprets /SET/FOO/bar.html as
+        # SET FOO bar
+        # and acts on the .html as a Content-Type request. This then breaks the
+        # assumption made in redbiom._requests where the return Content-Type is
+        # always JSON. While we are encoding characters to make them URL safe,
+        # Python's urllib.parse.quote_plus does not automatically encode
+        # "." characters.
+        # See: https://github.com/nicolasff/webdis#command-format
+        md = metadata.copy()
+        md['http_quoted_characters'] = ['a.html', 'b.html', 'foo/bar.html',
+                                        'baz.html', 'thing.html', 'stuff.html',
+                                        'asd#asd.html', 'a.html', 'b.html',
+                                        'foo.html']
+        redbiom.admin.load_sample_metadata(md)
+
+        exp = ['foo', 'bar', 'foo/bar', 'baz$12',
+               'thing', 'stuff', 'asd#asd', 'a', 'b', 'foo.html']
+        exp = ['a.html', 'b.html', 'foo/bar.html', 'baz.html', 'thing.html',
+               'stuff.html', 'asd#asd.html', 'a.html', 'b.html', 'foo.html']
+        obs = self.get('metadata:category', 'HGETALL',
+                       'http_quoted_characters')
+        self.assertEqual(sorted([v for k, v in obs.items()]),
+                         sorted(exp))
+
     def test_load_sample_metadata_full_search(self):
         redbiom.admin.load_sample_metadata(metadata)
         redbiom.admin.load_sample_metadata_full_search(metadata)

--- a/redbiom/tests/test_admin.py
+++ b/redbiom/tests/test_admin.py
@@ -72,6 +72,12 @@ class AdminTests(unittest.TestCase):
         self.se = redbiom._requests.make_script_exec(redbiom.get_config())
         redbiom.admin.ScriptManager.load_scripts(read_only=False)
 
+    def test_quote_plus(self):
+        data = ['foo.asd', 'bar/qwe', 'baz']
+        exp = ['foo%2Easd', 'bar%2Fqwe', 'baz']
+        for d, e in zip(data, exp):
+            self.assertEqual(redbiom.admin.quote_plus(d), e)
+
     def test_create_timestamp(self):
         today = datetime.datetime.now()
         today = datetime.datetime(today.year, today.month, today.day)


### PR DESCRIPTION
Webdis interprets `/SET/FOO/BAR.html` as `SET FOO BAR` in Redis. The `.html` gets used by Webdis as a request for a change in Content-Type. This alters the return response from Webdis and violates an assumption made by `redbiom._requests` that all returns are JSON. This resolves the issue by encoding "." as "2%E" per the encodings noted in the Webdis [command format](https://github.com/nicolasff/webdis#command-format) documentation. 