### PR TITLE
Resolve ambiguities

### DIFF
--- a/redbiom/commands/fetch.py
+++ b/redbiom/commands/fetch.py
@@ -62,6 +62,9 @@ def fetch_features_contained(context):
 @click.option('--tagged', is_flag=True, default=False,
               help=("Obtain the tag specific metadata (e.g., preparation "
                     "information)."))
+@click.option('--resolve-ambiguities', is_flag=True, default=False,
+              help=("Output unambiguous identifiers only. This option is "
+                    "incompatible with --tagged."))
 @click.option('--force-category', type=str, required=False, multiple=True,
               help=("Force the output to include specific metadata variables "
                     "if the metadata variable was observed in any of the "
@@ -69,12 +72,18 @@ def fetch_features_contained(context):
                     "multiple categories."))
 @click.argument('samples', nargs=-1)
 def fetch_sample_metadata(from_, samples, all_columns, context, output,
-                          tagged, force_category):
+                          tagged, force_category, resolve_ambiguities):
     """Retreive sample metadata."""
-    import redbiom.util
-    iterator = redbiom.util.from_or_nargs(from_, samples)
+    if resolve_ambiguities and tagged:
+        click.echo("Cannot resolve ambiguities and fetch tagged metadata",
+                   err=True)
+        click.exit(1)
 
+    import redbiom.util
     import redbiom.fetch
+    import pandas as pd
+
+    iterator = redbiom.util.from_or_nargs(from_, samples)
 
     if not force_category:
         force_category = None
@@ -83,6 +92,28 @@ def fetch_sample_metadata(from_, samples, all_columns, context, output,
                                              common=not all_columns,
                                              restrict_to=force_category,
                                              tagged=tagged)
+
+    if resolve_ambiguities:
+        md.set_index('#SampleID', inplace=True)
+
+        # a temporary key to use when resolving ambiguities
+        # that will be removed before writing the metadata
+        key = "__@@AMBIGUITY@@__"
+
+        # add ambiguity information into the frame
+        ambigs = pd.Series(map_)
+        ambigs = ambigs.loc[md.index]
+        md[key] = ambigs
+
+        # remove duplicated unambiguous identifiers
+        md = md[~md[key].duplicated()]
+
+        # remove our index, and replace the entries with the ambiguous names
+        md.reset_index(inplace=True)
+        md['#SampleID'] = md[key]
+
+        # cleanup
+        md.drop(columns=key, inplace=True)
 
     md.to_csv(output, sep='\t', header=True, index=False, encoding='utf-8')
 

--- a/redbiom/commands/fetch.py
+++ b/redbiom/commands/fetch.py
@@ -103,9 +103,14 @@ def fetch_sample_metadata(from_, samples, all_columns, context, output,
               help="Calculate and use MD5 for the features. This will also "
               "save a tsv file with the original feature name and the md5",
               default=False)
+@click.option('--resolve-ambiguities', required=False,
+              type=click.Choice(['merge', 'most-reads']), default=None,
+              help=("Resolve ambiguities that may be present in the samples "
+                    "which can arise from, for example, technical "
+                    "replicates."))
 @click.argument('features', nargs=-1)
 def fetch_samples_from_obserations(features, exact, from_, output,
-                                   context, md5):
+                                   context, md5, resolve_ambiguities):
     """Fetch sample data containing features."""
     import redbiom.util
     iterable = redbiom.util.from_or_nargs(from_, features)
@@ -117,6 +122,11 @@ def fetch_samples_from_obserations(features, exact, from_, output,
         tab, new_ids = redbiom.util.convert_biom_ids_to_md5(tab)
         with open(output + '.tsv', 'w') as f:
             f.write('\n'.join(['\t'.join(x) for x in new_ids.items()]))
+
+    if resolve_ambiguities == 'merge':
+        tab = redbiom.fetch._ambiguity_keep_most_reads(tab, map_)
+    elif resolve_ambiguities == 'most-reads':
+        tab = redbiom.fetch._ambiguity_merge(tab, map_)
 
     import h5py
     with h5py.File(output, 'w') as fp:
@@ -137,8 +147,14 @@ def fetch_samples_from_obserations(features, exact, from_, output,
               help="Calculate and use MD5 for the features. This will also "
               "save a tsv file with the original feature name and the md5",
               default=False)
+@click.option('--resolve-ambiguities', required=False,
+              type=click.Choice(['merge', 'most-reads']), default=None,
+              help=("Resolve ambiguities that may be present in the samples "
+                    "which can arise from, for example, technical "
+                    "replicates."))
 @click.argument('samples', nargs=-1)
-def fetch_samples_from_samples(samples, from_, output, context, md5):
+def fetch_samples_from_samples(samples, from_, output, context, md5,
+                               resolve_ambiguities):
     """Fetch sample data."""
     import redbiom.util
     iterable = redbiom.util.from_or_nargs(from_, samples)
@@ -150,6 +166,11 @@ def fetch_samples_from_samples(samples, from_, output, context, md5):
         table, new_ids = redbiom.util.convert_biom_ids_to_md5(table)
         with open(output + '.tsv', 'w') as f:
             f.write('\n'.join(['\t'.join(x) for x in new_ids.items()]))
+
+    if resolve_ambiguities == 'merge':
+        table = redbiom.fetch._ambiguity_keep_most_reads(table, ambig)
+    elif resolve_ambiguities == 'most-reads':
+        table = redbiom.fetch._ambiguity_merge(table, ambig)
 
     import h5py
     with h5py.File(output, 'w') as fp:

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -186,7 +186,7 @@ def sample_metadata(samples, common=True, context=None, restrict_to=None,
         else:
             ambig_map = {v: k.split('_', 1)[1] for k, v in rbid_map.items()}
     else:
-        ambig_assoc = {k: k for k in samples}
+        ambig_assoc = {k: [k] for k in samples}
 
     if not ambig_assoc:
         raise ValueError("None of the samples were found in the context")

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -381,7 +381,12 @@ def _biom_from_samples(context, samples, get=None, normalize_taxonomy=None):
     table = biom.Table(mat, obs_ids, sample_ids, obs_md)
     table.update_ids(rimap)
 
-    return table, stable_ids
+    ambiguity_map = {}
+    for k, v in rimap.items():
+        tag, id_ = k.split('_', 1)
+        ambiguity_map[v] = id_
+
+    return table, ambiguity_map
 
 
 def taxon_ancestors(context, ids, get=None, normalize=None):

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -381,7 +381,7 @@ def _biom_from_samples(context, samples, get=None, normalize_taxonomy=None):
     table = biom.Table(mat, obs_ids, sample_ids, obs_md)
     table.update_ids(rimap)
 
-    return table, ambig_assoc
+    return table, stable_ids
 
 
 def taxon_ancestors(context, ids, get=None, normalize=None):

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -175,14 +175,18 @@ def sample_metadata(samples, common=True, context=None, restrict_to=None,
     samples = untagged + tagged_clean
 
     # resolve ambiguities
+    ambig_map = {}
     if context is not None:
         _, _, ambig_assoc, rbid_map = \
             redbiom.util.resolve_ambiguities(context, samples, get)
 
         if tagged:
             ambig_assoc = {rbid: [rbid] for rbid in rbid_map}
+            ambig_map = {rbid: rbid for rbid in rbid_map}
+        else:
+            ambig_map = {v: k.split('_', 1)[1] for k, v in rbid_map.items()}
     else:
-        ambig_assoc = {k: [k] for k in samples}
+        ambig_assoc = {k: k for k in samples}
 
     if not ambig_assoc:
         raise ValueError("None of the samples were found in the context")
@@ -235,7 +239,7 @@ def sample_metadata(samples, common=True, context=None, restrict_to=None,
             new_ids.append("%s.%s" % (id_, tag))
         md['#SampleID'] = new_ids
 
-    return md, ambig_assoc
+    return md, ambig_map
 
 
 def data_from_features(context, features, exact):

--- a/redbiom/tests/test_fetch.py
+++ b/redbiom/tests/test_fetch.py
@@ -255,6 +255,7 @@ class FetchTests(unittest.TestCase):
         exp = metadata.copy()
         exp.set_index('#SampleID', inplace=True)
         obs, ambig = sample_metadata(table.ids(), common=False)
+
         obs.set_index('#SampleID', inplace=True)
         self.assertEqual(sorted(exp.index), sorted(obs.index))
         self.assertTrue(set(obs.columns).issubset(exp.columns))

--- a/redbiom/tests/test_fetch.py
+++ b/redbiom/tests/test_fetch.py
@@ -10,7 +10,10 @@ import redbiom.admin
 import redbiom.fetch
 from redbiom.fetch import (_biom_from_samples, sample_metadata,
                            samples_in_context, features_in_context,
-                           sample_counts_per_category, get_sample_values)
+                           sample_counts_per_category, get_sample_values,
+                           _ambiguity_keep_most_reads, _ambiguity_merge,
+                           _resolve_ambiguity)
+
 from redbiom.tests import assert_test_env
 
 assert_test_env()
@@ -354,6 +357,52 @@ class FetchTests(unittest.TestCase):
         self.assertEqual(len(obs), 2)
         self.assertEqual(obs['LATITUDE'], 10)
         self.assertEqual(obs['LONGITUDE'], 10)
+
+    def test_resolve_ambiguities(self):
+        other = ['blah.123', 'blah2.456', 'foo.X', 'foo.Y', 'bar.X', 'bar.Z']
+
+        exp = {'foo.X': 'foo',
+               'foo.Y': 'foo',
+               'bar.X': 'bar',
+               'bar.Z': 'bar',
+               'blah.123': 'blah',
+               'blah2.456': 'blah2'}
+
+        obs = _resolve_ambiguity(other)
+        self.assertEqual(obs, exp)
+
+    def test_ambiguity_merge(self):
+        table = biom.Table(np.array([[0, 1, 2, 3],
+                                     [4, 5, 6, 7],
+                                     [8, 9, 10, 11]]),
+                           ['O1', 'O2', 'O3'],
+                           ['10317.1234.foo',
+                            '10317.1234.bar',
+                            '10317.4321.foo',
+                            '10317.1234.baz'])
+        exp_table = biom.Table(np.array([[4, 2], [16, 6], [28, 10]]),
+                               ['O1', 'O2', 'O3'],
+                               ['10317.1234', '10317.4321'])
+        obs_table = _ambiguity_merge(table)
+        obs_table.del_metadata()
+        self.assertEqual(obs_table, exp_table)
+
+    def test_ambiguity_keep_most_reads(self):
+        table = biom.Table(np.array([[0, 3, 2, 1],
+                                     [4, 7, 6, 5],
+                                     [8, 11, 10, 9]]),
+                           ['O1', 'O2', 'O3'],
+                           ['10317.1234.foo',
+                            '10317.1234.bar',
+                            '10317.4321.foo',
+                            '10317.1234.baz'])
+
+        exp_table = biom.Table(np.array([[3, 2], [7, 6], [11, 10]]),
+                               ['O1', 'O2', 'O3'],
+                               ['10317.1234', '10317.4321'])
+
+        obs_table = _ambiguity_keep_most_reads(table)
+        self.assertEqual(obs_table, exp_table)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This partially addresses #58 and allows for ambiguities to be resolved on fetch through either merging, or taking the sample with the most sequencing data.