### PR TITLE
WIP: Closing out a few issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install
       shell: bash -l {0}
       run: |
-        conda create --yes -n test-env python=${{ matrix.python-version }} requests pandas click redis h5py nose cython
+        conda create --yes -n test-env python=${{ matrix.python-version }} requests pandas click redis h5py nose cython future
         conda activate test-env
         conda install -c conda-forge --yes scikit-bio biom-format
         pip install flake8 nltk msgpack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # based roughly on https://github.com/conda-incubator/setup-miniconda#example-1-basic-usage
         # via biocore/empress
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Check out repository code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # based roughly on https://github.com/conda-incubator/setup-miniconda#example-1-basic-usage
         # via biocore/empress
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - name: Check out repository code

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ test: test_db
 	/bin/bash test.sh
 	nosetests
 	/bin/bash test_failures.sh  # this blows away the db
+	/bin/bash test_external.sh  # relies on public redbiom instance
 
 test_bulk: test_db_bulk
 	/bin/bash test.sh

--- a/redbiom/_requests.py
+++ b/redbiom/_requests.py
@@ -104,10 +104,12 @@ def make_script_exec(config):
     config = redbiom.get_config()
 
     def f(sha, *args):
-        payload = [config['hostname'], 'EVALSHA', sha]
+        payload = [sha]
         payload.extend([str(a) for a in args])
-        url = '/'.join(payload)
-        return json.loads(_parse_validate_request(s.get(url), 'EVALSHA'))
+        payload = '/'.join(payload)
+        data = _format_request(None, 'EVALSHA', payload)
+        req = s.post(config['hostname'], data=data)
+        return json.loads(req.json()['EVALSHA'])
 
     return f
 

--- a/redbiom/admin.py
+++ b/redbiom/admin.py
@@ -251,8 +251,13 @@ def create_context(name, description):
 
     config = redbiom.get_config()
     post = redbiom._requests.make_post(config)
-    post('state', 'HSET', "contexts/%s/%s" % (name, description))
-    post(name, 'HSET', "state/db-version/%s" % redbiom.__db_version__)
+    try:
+        post('state', 'HSET', "contexts/%s/%s" % (name, description))
+        post(name, 'HSET', "state/db-version/%s" % redbiom.__db_version__)
+    except:  # noqa
+        import sys
+        print("Unable to create context: %s" % name, file=sys.stderr)
+        raise
     ScriptManager.load_scripts()
 
 

--- a/redbiom/admin.py
+++ b/redbiom/admin.py
@@ -566,7 +566,7 @@ def load_sample_metadata(md, tag=None):
 
     # subset to only the novel IDs
     represented = get('metadata', 'SMEMBERS', 'samples-represented')
-    md = md.loc[set(md.index) - set(represented)]
+    md = md.loc[list(set(md.index) - set(represented))]
     if len(md) == 0:
         return 0
 

--- a/redbiom/commands/fetch.py
+++ b/redbiom/commands/fetch.py
@@ -284,7 +284,7 @@ def qiita_study(study_id, context, resolve_ambiguities, skip_taxonomy,
 
     if md5:
         table, new_ids = redbiom.util.convert_biom_ids_to_md5(table)
-        with open(output + '.tsv', 'w') as f:
+        with open(output_basename + 'md5mapping.tsv', 'w') as f:
             f.write('\n'.join(['\t'.join(x) for x in new_ids.items()]))
 
     if resolve_ambiguities == 'merge':
@@ -297,8 +297,7 @@ def qiita_study(study_id, context, resolve_ambiguities, skip_taxonomy,
     md, map_ = redbiom.fetch.sample_metadata(samples, context=context,
                                              common=False, tagged=False)
 
-    md_resolve_ambiguities = resolve_ambiguities in ('merge', 'most-reads')
-    if md_resolve_ambiguities:
+    if resolve_ambiguities in ('merge', 'most-reads'):
         if resolve_ambiguities == 'most-reads' and retain_artifact_id:
             pass
         else:
@@ -316,7 +315,8 @@ def qiita_study(study_id, context, resolve_ambiguities, skip_taxonomy,
             # remove duplicated unambiguous identifiers
             md = md[~md[key].duplicated()]
 
-            # remove our index, and replace the entries with the ambiguous names
+            # remove our index, and replace the entries with the ambiguous
+            # names
             md.reset_index(inplace=True)
             md['#SampleID'] = md[key]
 

--- a/redbiom/commands/fetch.py
+++ b/redbiom/commands/fetch.py
@@ -143,11 +143,19 @@ def fetch_sample_metadata(from_, samples, all_columns, context, output,
 @click.option('--skip-taxonomy', is_flag=True, default=False, required=False,
               help=("Do not resolve taxonomy on fetch. Setting this flag can "
                     "reduce the time required to complete a fetch"))
+@click.option('--retain-artifact-id', is_flag=True, default=False,
+              required=False,
+              help=("If using --resolve-ambiguities=most-reads, set this flag "
+                    "to retain the artifact ID of the sample kept"))
 @click.argument('features', nargs=-1)
 def fetch_samples_from_obserations(features, exact, from_, output,
                                    context, md5, resolve_ambiguities,
-                                   skip_taxonomy):
+                                   skip_taxonomy, retain_artifact_id):
     """Fetch sample data containing features."""
+    if retain_artifact_id and resolve_ambiguities != 'merge-reads':
+        raise ValueError('--retain-artifact-id only impacts a merge-reads '
+                         'ambiguity resolution')
+
     import redbiom.util
     iterable = redbiom.util.from_or_nargs(from_, features)
 
@@ -163,7 +171,8 @@ def fetch_samples_from_obserations(features, exact, from_, output,
     if resolve_ambiguities == 'merge':
         tab = redbiom.fetch._ambiguity_merge(tab, map_)
     elif resolve_ambiguities == 'most-reads':
-        tab = redbiom.fetch._ambiguity_keep_most_reads(tab, map_)
+        tab = redbiom.fetch._ambiguity_keep_most_reads(tab, map_,
+                                                       retain_artifact_id)
 
     import h5py
     with h5py.File(output, 'w') as fp:
@@ -192,10 +201,19 @@ def fetch_samples_from_obserations(features, exact, from_, output,
 @click.option('--skip-taxonomy', is_flag=True, default=False, required=False,
               help=("Do not resolve taxonomy on fetch. Setting this flag can "
                     "reduce the time required to complete a fetch"))
+@click.option('--retain-artifact-id', is_flag=True, default=False,
+              required=False,
+              help=("If using --resolve-ambiguities=most-reads, set this flag "
+                    "to retain the artifact ID of the sample kept"))
 @click.argument('samples', nargs=-1)
 def fetch_samples_from_samples(samples, from_, output, context, md5,
-                               resolve_ambiguities, skip_taxonomy):
+                               resolve_ambiguities, skip_taxonomy,
+                               retain_artifact_id):
     """Fetch sample data."""
+    if retain_artifact_id and resolve_ambiguities != 'merge-reads':
+        raise ValueError('--retain-artifact-id only impacts a merge-reads '
+                         'ambiguity resolution')
+
     import redbiom.util
     iterable = redbiom.util.from_or_nargs(from_, samples)
 
@@ -211,7 +229,8 @@ def fetch_samples_from_samples(samples, from_, output, context, md5,
     if resolve_ambiguities == 'merge':
         table = redbiom.fetch._ambiguity_merge(table, ambig)
     elif resolve_ambiguities == 'most-reads':
-        table = redbiom.fetch._ambiguity_keep_most_reads(table, ambig)
+        table = redbiom.fetch._ambiguity_keep_most_reads(table, ambig,
+                                                         retain_artifact_id)
 
     import h5py
     with h5py.File(output, 'w') as fp:

--- a/redbiom/commands/fetch.py
+++ b/redbiom/commands/fetch.py
@@ -140,9 +140,10 @@ def fetch_sample_metadata(from_, samples, all_columns, context, output,
               help=("Resolve ambiguities that may be present in the samples "
                     "which can arise from, for example, technical "
                     "replicates."))
-@click.option('--skip-taxonomy', is_flag=True, default=False, required=False,
-              help=("Do not resolve taxonomy on fetch. Setting this flag can "
-                    "reduce the time required to complete a fetch"))
+@click.option('--fetch-taxonomy', is_flag=True, default=False, required=False,
+              help=("Resolve taxonomy on fetch. Setting this flag increases "
+                    "the time required to complete a fetch. Note that Deblur "
+                    "contexts do not cache taxonomy."))
 @click.option('--retain-artifact-id', is_flag=True, default=False,
               required=False,
               help=("If using --resolve-ambiguities=most-reads, set this flag "
@@ -150,7 +151,7 @@ def fetch_sample_metadata(from_, samples, all_columns, context, output,
 @click.argument('features', nargs=-1)
 def fetch_samples_from_obserations(features, exact, from_, output,
                                    context, md5, resolve_ambiguities,
-                                   skip_taxonomy, retain_artifact_id):
+                                   fetch_taxonomy, retain_artifact_id):
     """Fetch sample data containing features."""
     if retain_artifact_id and resolve_ambiguities != 'merge-reads':
         raise ValueError('--retain-artifact-id only impacts a merge-reads '
@@ -160,6 +161,7 @@ def fetch_samples_from_obserations(features, exact, from_, output,
     iterable = redbiom.util.from_or_nargs(from_, features)
 
     import redbiom.fetch
+    skip_taxonomy = not fetch_taxonomy
     tab, map_ = redbiom.fetch.data_from_features(context, iterable, exact,
                                                  skip_taxonomy=skip_taxonomy)
 
@@ -198,16 +200,17 @@ def fetch_samples_from_obserations(features, exact, from_, output,
               help=("Resolve ambiguities that may be present in the samples "
                     "which can arise from, for example, technical "
                     "replicates."))
-@click.option('--skip-taxonomy', is_flag=True, default=False, required=False,
-              help=("Do not resolve taxonomy on fetch. Setting this flag can "
-                    "reduce the time required to complete a fetch"))
+@click.option('--fetch-taxonomy', is_flag=True, default=False, required=False,
+              help=("Resolve taxonomy on fetch. Setting this flag increases "
+                    "the time required to complete a fetch. Note that Deblur "
+                    "contexts do not cache taxonomy."))
 @click.option('--retain-artifact-id', is_flag=True, default=False,
               required=False,
               help=("If using --resolve-ambiguities=most-reads, set this flag "
                     "to retain the artifact ID of the sample kept"))
 @click.argument('samples', nargs=-1)
 def fetch_samples_from_samples(samples, from_, output, context, md5,
-                               resolve_ambiguities, skip_taxonomy,
+                               resolve_ambiguities, fetch_taxonomy,
                                retain_artifact_id):
     """Fetch sample data."""
     if retain_artifact_id and resolve_ambiguities != 'merge-reads':
@@ -218,6 +221,7 @@ def fetch_samples_from_samples(samples, from_, output, context, md5,
     iterable = redbiom.util.from_or_nargs(from_, samples)
 
     import redbiom.fetch
+    skip_taxonomy = not fetch_taxonomy
     table, ambig = redbiom.fetch.data_from_samples(context, iterable,
                                                    skip_taxonomy=skip_taxonomy)
 
@@ -247,9 +251,10 @@ def fetch_samples_from_samples(samples, from_, output, context, md5,
               help=("Resolve ambiguities that may be present in the samples "
                     "which can arise from, for example, technical "
                     "replicates."))
-@click.option('--skip-taxonomy', is_flag=True, default=False, required=False,
-              help=("Do not resolve taxonomy on fetch. Setting this flag can "
-                    "reduce the time required to complete a fetch"))
+@click.option('--fetch-taxonomy', is_flag=True, default=False, required=False,
+              help=("Resolve taxonomy on fetch. Setting this flag increases "
+                    "the time required to complete a fetch. Note that Deblur "
+                    "contexts do not cache taxonomy."))
 @click.option('--retain-artifact-id', is_flag=True, default=False,
               required=False,
               help=("If using --resolve-ambiguities=most-reads, set this flag "
@@ -263,7 +268,7 @@ def fetch_samples_from_samples(samples, from_, output, context, md5,
               help="Calculate and use MD5 for the features. This will also "
               "save a tsv file with the original feature name and the md5",
               default=False)
-def qiita_study(study_id, context, resolve_ambiguities, skip_taxonomy,
+def qiita_study(study_id, context, resolve_ambiguities, fetch_taxonomy,
                 retain_artifact_id, remove_blanks, output_basename, md5):
     """Fetch sample data from a Qiita study."""
     if retain_artifact_id and resolve_ambiguities != 'merge-reads':
@@ -274,6 +279,7 @@ def qiita_study(study_id, context, resolve_ambiguities, skip_taxonomy,
     samples = list(redbiom.search.metadata_full(query, categories=False))
 
     import redbiom.fetch
+    skip_taxonomy = not fetch_taxonomy
     table, ambig = redbiom.fetch.data_from_samples(context, samples,
                                                    skip_taxonomy=skip_taxonomy)
 

--- a/redbiom/commands/search.py
+++ b/redbiom/commands/search.py
@@ -117,12 +117,13 @@ def search_metadata(query, categories):
     $ redbiom search metadata --categories "ph - water"
     """
     import redbiom.search
+    import sys
+
     try:
         for i in redbiom.search.metadata_full(query, categories):
             click.echo(i)
-    except TypeError:
-        import sys
-        click.echo("The search query appears to be malformed. ")
+    except (TypeError, SyntaxError):
+        click.echo("The search query appears to be malformed.")
         sys.exit(1)
 
 

--- a/redbiom/commands/search.py
+++ b/redbiom/commands/search.py
@@ -117,8 +117,13 @@ def search_metadata(query, categories):
     $ redbiom search metadata --categories "ph - water"
     """
     import redbiom.search
-    for i in redbiom.search.metadata_full(query, categories):
-        click.echo(i)
+    try:
+        for i in redbiom.search.metadata_full(query, categories):
+            click.echo(i)
+    except TypeError:
+        import sys
+        click.echo("The search query appears to be malformed. ")
+        sys.exit(1)
 
 
 @search.command(name='taxon')

--- a/redbiom/commands/summarize.py
+++ b/redbiom/commands/summarize.py
@@ -205,6 +205,11 @@ def taxonomy(from_, context, normalize_ranks, features):
     lineages = redbiom.fetch.taxon_ancestors(context, ids,
                                              normalize=normalize_ranks)
 
+    if lineages is None:
+        import sys
+        click.echo("No taxonomy information found.")
+        sys.exit(0)
+
     import skbio
     tree = skbio.TreeNode.from_taxonomy([(i, l)
                                          for i, l in zip(ids, lineages)])

--- a/redbiom/commands/summarize.py
+++ b/redbiom/commands/summarize.py
@@ -205,7 +205,7 @@ def taxonomy(from_, context, normalize_ranks, features):
     lineages = redbiom.fetch.taxon_ancestors(context, ids,
                                              normalize=normalize_ranks)
 
-    if lineages is None:
+    if not lineages:
         import sys
         click.echo("No taxonomy information found.")
         sys.exit(0)

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -431,21 +431,11 @@ def taxon_ancestors(context, ids, get=None, normalize=None):
     """
     from future.moves.itertools import zip_longest
     import redbiom._requests
-    import re
 
     if get is None:
         import redbiom
         config = redbiom.get_config()
         get = redbiom._requests.make_get(config)
-
-    is_asv = re.compile(r"^[ATGC]{90}")
-    non_asvs = []
-    for i in ids:
-        if not is_asv.match(i):
-            non_asvs.append(i)
-    ids = non_asvs
-    if not ids:
-        return None
 
     hmgetter = redbiom._requests.buffered
     remapped_bulk = hmgetter(iter(ids), None, 'HMGET', context,

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -798,7 +798,7 @@ def _ambiguity_merge(table, collapse_map):
     return collapsed_table
 
 
-def _ambiguity_keep_most_reads(table, ambig_map):
+def _ambiguity_keep_most_reads(table, ambig_map, retain_artifact_id=False):
     """Keep the ambiguous sample with the most reads
 
     Parameters
@@ -807,6 +807,8 @@ def _ambiguity_keep_most_reads(table, ambig_map):
         The table obtained from redbiom
     ambig_map : dict
         A mapping of a sample ID in the table to its ambiguous form.
+    retain_artifact_id : boolean, default False
+        If True, do not strip the artifact ID
 
     Returns
     -------
@@ -841,6 +843,8 @@ def _ambiguity_keep_most_reads(table, ambig_map):
             to_keep.append(sample_ids[0])
 
     subset_table = table.filter(set(to_keep), inplace=False).remove_empty()
-    subset_table.update_ids(ambig_map, inplace=True)
+
+    if not retain_artifact_id:
+        subset_table.update_ids(ambig_map, inplace=True)
 
     return subset_table

--- a/redbiom/fetch.py
+++ b/redbiom/fetch.py
@@ -379,9 +379,8 @@ def _biom_from_samples(context, samples, get=None, normalize_taxonomy=None,
     sample_ids = [id_ for id_, _ in table_data]
 
     # fill in the matrix
-    mat = ss.lil_matrix((len(unique_indices), len(table_data)))
+    mat = ss.dok_matrix((len(unique_indices), len(table_data)))
     for col, (sample, col_data) in enumerate(table_data):
-        # since this isn't dense, hopefully roworder doesn't hose us
         for obs_id, value in col_data.items():
             mat[unique_indices_map[obs_id], col] = value
 

--- a/redbiom/search.py
+++ b/redbiom/search.py
@@ -93,9 +93,16 @@ def query_plan(query):
         return [('where', part)]
 
     parts = query.split('where', 1)
-    for part in parts:
+    for i, part in enumerate(parts):
         if not part:
             raise ValueError('No query')
+
+        parts[i] = parts[i].strip()
+
+    if ' ' in parts[0]:
+        import sys
+        print("Set queries cannot contain spaces.", file=sys.stderr)
+        raise SyntaxError
 
     if len(parts) == 1:
         return [('set', parts[0].strip())]

--- a/redbiom/search.py
+++ b/redbiom/search.py
@@ -99,11 +99,6 @@ def query_plan(query):
 
         parts[i] = parts[i].strip()
 
-    if ' ' in parts[0]:
-        import sys
-        print("Set queries cannot contain spaces.", file=sys.stderr)
-        raise SyntaxError
-
     if len(parts) == 1:
         return [('set', parts[0].strip())]
     else:

--- a/redbiom/tests/test_fetch.py
+++ b/redbiom/tests/test_fetch.py
@@ -418,6 +418,28 @@ class FetchTests(unittest.TestCase):
         obs_table = _ambiguity_keep_most_reads(table, ambig_map)
         self.assertEqual(obs_table, exp_table)
 
+    def test_ambiguity_keep_most_reads_retain_artifact_id(self):
+        ambig_map = {'10317.1234.foo': '10317.1234',
+                     '10317.1234.bar': '10317.1234',
+                     '10317.4321.foo': '10317.4321',
+                     '10317.1234.baz': '10317.1234'}
+
+        table = biom.Table(np.array([[0, 3, 2, 1],
+                                     [4, 7, 6, 5],
+                                     [8, 11, 10, 9]]),
+                           ['O1', 'O2', 'O3'],
+                           ['10317.1234.foo',
+                            '10317.1234.bar',
+                            '10317.4321.foo',
+                            '10317.1234.baz'])
+
+        exp_table = biom.Table(np.array([[3, 2], [7, 6], [11, 10]]),
+                               ['O1', 'O2', 'O3'],
+                               ['10317.1234.bar', '10317.4321.foo'])
+
+        obs_table = _ambiguity_keep_most_reads(table, ambig_map, True)
+        self.assertEqual(obs_table, exp_table)
+
     def test_ambiguity_keep_most_reads_mismatch(self):
         ambig_map = {'10317.1234.foo': '10317.1234',
                      '10317.4321.foo': '10317.4321',

--- a/redbiom/tests/test_fetch.py
+++ b/redbiom/tests/test_fetch.py
@@ -5,7 +5,7 @@ from future.moves.itertools import zip_longest
 import numpy as np
 import biom
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 
 import redbiom.admin
 import redbiom.fetch

--- a/redbiom/tests/test_where_expr.py
+++ b/redbiom/tests/test_where_expr.py
@@ -52,6 +52,8 @@ class WhereTests(unittest.TestCase):
                  ("(age >= 5) <= 15", {'D', 'C'}),
                  ("sex == 'male'", {'D', }),
                  ("sex in ('male', 'female')", {'A', 'B', 'D'}),
+                 ("'male' in sex", {'D', }),
+                 ("'male' not in sex", {'A', 'B', 'C'}),
                  ("sex is 'male' or age < 11", {'D', 'A', 'C'}),
                  ("(age <= 10) != 8 and sex is 'male'", {'D', }),
                  ("(age <= 10) != 8 or sex is 'male'", {'D', 'A', 'C'}),

--- a/redbiom/where_expr.py
+++ b/redbiom/where_expr.py
@@ -99,11 +99,21 @@ IsNot = NotEq
 
 
 def _in(left, right):
-    return left[left.isin(right)]
+    if isinstance(right, tuple):
+        # some_category in foo
+        return left[left.isin(right)]
+    else:
+        # foo in some_category
+        return right[right.isin([left])]
 
 
 def _notin(left, right):
-    return left[~left.isin(right)]
+    if isinstance(right, tuple):
+        # some_category not in foo
+        return left[~left.isin(right)]
+    else:
+        # foo not in some_category
+        return right[~right.isin([left])]
 
 
 def Or():

--- a/redbiom/where_expr.py
+++ b/redbiom/where_expr.py
@@ -104,6 +104,9 @@ def _in(left, right):
         return left[left.isin(right)]
     else:
         # foo in some_category
+        if len(right) == 0:
+            return pd.Series([])
+
         return right[right.isin([left])]
 
 

--- a/test.sh
+++ b/test.sh
@@ -226,3 +226,9 @@ redbiom search samples --context test 10317.000003302 | sort - > obs_sample_sear
 redbiom search samples --context test UNTAGGED_10317.000003302 | sort - > obs_sample_search_rbid.txt
 md5test obs_sample_search.txt exp_sample_search.txt
 md5test obs_sample_search_rbid.txt exp_sample_search.txt
+
+if [[ $(redbiom search metadata "where 'feces' in BODY_SITE" | wc -l | awk '{ print $1 }') != "9" ]];
+then
+    echo "fail"
+    exit 1
+fi

--- a/test.sh
+++ b/test.sh
@@ -227,7 +227,7 @@ redbiom search samples --context test UNTAGGED_10317.000003302 | sort - > obs_sa
 md5test obs_sample_search.txt exp_sample_search.txt
 md5test obs_sample_search_rbid.txt exp_sample_search.txt
 
-if [[ $(redbiom search metadata "where 'feces' in BODY_SITE" | wc -l | awk '{ print $1 }') != "9" ]];
+if [[ $(redbiom search metadata "where 'UBERON:feces' in BODY_SITE" | wc -l | awk '{ print $1 }') != "11" ]];
 then
     echo "fail"
     exit 1

--- a/test_external.sh
+++ b/test_external.sh
@@ -27,3 +27,6 @@ if [[ ! ${in_table} -eq 450 ]];
 then
     exit 1
 fi
+
+# see https://github.com/biocore/redbiom/issues/117
+redbiom fetch samples --context Deblur_2021.09-Illumina-16S-V4-150nt-ac8c0b --output samples.biom 11896.A2.raw

--- a/test_external.sh
+++ b/test_external.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -x 
+set -e
+
+unset REDBIOM_HOST
+
+# WARNING: the context is not assured to be stable. It is possible
+# that in the future, the context name will change and this test
+# will fail. However, that is unlikely to happen anytime soon so
+# let's do the simple thing of hard coding it.
+redbiom fetch qiita-study \
+    --study-id 2136 \
+    --context Deblur_2021.09-Illumina-16S-V4-90nt-dd6875 \
+    --output-basename 2136test \
+    --resolve-ambiguities most-reads \
+    --remove-blanks
+
+in_table=$(biom table-ids -i 2136test.biom | wc -l)
+in_md=$(grep "^2136" 2136test.tsv | wc -l)
+if [[ ${in_table} != ${in_md} ]];
+then
+    exit 1
+fi
+
+if [[ ! ${in_table} -eq 450 ]];
+then
+    exit 1
+fi


### PR DESCRIPTION
Closing out a few issues

* fixes #119
* fixes #117 
* fixes #116 
* fixes #43 
* fixes #44 
* fixes #46 
* fixes #52 
* fixes #50 
* fixes #41

We also introduce a performance improvement which reduces runtime for fetching the EMP500 (qiita study 13114) by over 50%. These gains are achieved by (a) avoiding taxonomy lookup for ASVs and (b) doubling buffer sizes for key calls to reduce HTTP requests. We did not observe further reductions in runtime by increasing buffers further. 