### PR TITLE
Latin1 bug

### DIFF
--- a/redbiom/_requests.py
+++ b/redbiom/_requests.py
@@ -6,12 +6,17 @@ def _parse_validate_request(req, command):
     return req.json()[command]
 
 
-def _format_request(context, command, other):
+def _format_request(context, command, other, as_bytes=False):
     """Merge commands, context and payload"""
     if context is None:
-        return "%s/%s.json" % (command, other)
+        data = "%s/%s.json" % (command, other)
     else:
-        return "%s/%s:%s.json" % (command, context, other)
+        data = "%s/%s:%s.json" % (command, context, other)
+
+    if as_bytes:
+        return data.encode('utf-8')
+    else:
+        return data
 
 
 def get_session():
@@ -55,7 +60,8 @@ def make_post(config, redis_protocol=None):
     else:
         def f(context, cmd, payload, verbose=False):
             req = s.post(config['hostname'],
-                         data=_format_request(context, cmd, payload))
+                         data=_format_request(context, cmd, payload,
+                                              as_bytes=True))
 
             if verbose:
                 print(context, cmd, payload[:100])

--- a/redbiom/tests/test_admin.py
+++ b/redbiom/tests/test_admin.py
@@ -343,8 +343,14 @@ class AdminTests(unittest.TestCase):
         self.assertIn(cur + '.raw', obs)
 
     def test_load_sample_metadata_full_search(self):
-        redbiom.admin.load_sample_metadata(metadata)
-        redbiom.admin.load_sample_metadata_full_search(metadata)
+        md = metadata.copy()
+
+        # valid portion of a name in Czech Republic, but which does not encode
+        # in python's http client
+        md.iloc[0]['STATE'] = "Vysočina"
+
+        redbiom.admin.load_sample_metadata(md)
+        redbiom.admin.load_sample_metadata_full_search(md)
         tests = [('agp-skin', {'10317.000003302', }),
 
                  # an example of a misleading query. only those AG samples


### PR DESCRIPTION
We discovered an issue on load of data using `č` characters, causing load operations to bomb on Python's HTTP client. This patch fixes the immediate issue. Addressing other HTTP actions may be necessary but unclear at the moment. 

cc @cassidysymons @antgonza

```
Traceback (most recent call last):
  File "/home/qiita/redbiom-loader/redbiom-qiita-loader-amplicon-wgs.py", line 259, in load_study_metadata
    redbiom.admin.load_sample_metadata_full_search(df)
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/redbiom/admin.py", line 657, in load_sample_
metadata_full_search
    post('metadata', 'SADD', payload)
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/redbiom/_requests.py", line 57, in f
    req = s.post(config['hostname'],
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/requests/sessions.py", line 577, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/requests/sessions.py", line 529, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/requests/sessions.py", line 645, in send
    r = adapter.send(request, **kwargs)
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/requests/adapters.py", line 440, in send
    resp = conn.urlopen(
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/urllib3/connectionpool.py", line 703, in url
open
    httplib_response = self._make_request(
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/urllib3/connectionpool.py", line 398, in _ma
ke_request
    conn.request(method, url, **httplib_request_kw)
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/site-packages/urllib3/connection.py", line 239, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/http/client.py", line 1285, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/http/client.py", line 1330, in _send_request
    body = _encode(body, 'body')
  File "/home/qiita/miniconda3/envs/qiita/lib/python3.9/http/client.py", line 168, in _encode
    raise UnicodeEncodeError(
UnicodeEncodeError: 'latin-1' codec can't encode character '\u010d' in position 30: Body ('č') is not valid Latin-
1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```